### PR TITLE
Improve project documentation and fix mod metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing to Worn Path
+
+## Building the Project
+
+Requires Java 21. Then run:
+
+```sh
+./gradlew build
+```
+
+## Submitting Issues
+
+Please use [GitHub Issues](https://github.com/edward3h/worn-path/issues) to report bugs or request features.
+
+## Pull Requests
+
+1. Fork the repository and create a feature branch.
+2. Make your changes, ensuring the project builds cleanly (`./gradlew build`).
+3. Open a pull request against `main`.
+
+## Code Conventions
+
+- **Package**: `red.ethel.minecraft.wornpath`
+  - Platform-specific: `.fabric`, `.neoforge`
+  - Mixins: `.mixin`
+- **Mod ID**: `worn_path`
+- **Java**: 21, standard conventions
+- Platform-agnostic logic goes in `common/`. Each platform subproject has a thin entry point that delegates to common code.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 edward3h
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,72 @@
 # Worn Path
 
-Minecraft mod.
+An Architectury-based Minecraft mod for Fabric and NeoForge (MC 1.21.10).
+Where players walk, paths may appear.
+
+## For Players
+
+### What Does It Do?
+
+Worn Path gradually transforms blocks beneath frequently walked areas into
+path blocks. The more players traverse a route, the more defined the path
+becomes.
+
+### Installation
+
+1. Install [Fabric Loader](https://fabricmc.net/) (0.18.4+) or
+   [NeoForge](https://neoforged.net/) (21.10+) for Minecraft 1.21.10.
+2. Install the [Architectury API](https://modrinth.com/mod/architectury-api)
+   for your platform.
+3. Drop the appropriate Worn Path `.jar` into your `mods/` folder.
+
+### Compatibility
+
+| Platform | Minecraft | Loader |
+|---|---|---|
+| Fabric | 1.21.10 | Fabric Loader 0.18.4+ |
+| NeoForge | 1.21.10 | NeoForge 21.10+ |
+
+Both platforms require the Architectury API (18.0.6+).
+
+## For Developers
+
+### Building
+
+Requires Java 21 (managed via [asdf](https://asdf-vm.com/), see `.tool-versions`).
+
+```sh
+./gradlew build
+```
+
+Build artefacts are produced for both Fabric and NeoForge platforms.
+
+### Project Structure
+
+This is a multi-platform [Architectury](https://docs.architectury.dev/) project:
+
+- `common/` — Shared code across all platforms
+- `fabric/` — Fabric-specific implementation
+- `neoforge/` — NeoForge-specific implementation
+
+Platform-agnostic logic goes in `common/`. Each platform subproject has a thin
+entry point that delegates to common code.
+
+### Key Dependencies
+
+| Dependency | Version |
+|---|---|
+| Minecraft | 1.21.10 |
+| Fabric Loader | 0.18.4+ |
+| Fabric API | 0.138.4+1.21.10 |
+| NeoForge | 21.10.34-beta |
+| Architectury API | 18.0.6+ |
+| Caffeine (caching) | 3.2.0 |
+
+### Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on building, submitting
+issues, and code conventions.
+
+## Licence
+
+This project is licensed under the [MIT Licence](LICENSE).

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -8,10 +8,10 @@
     "edward3h"
   ],
   "contact": {
-    "homepage": "https://fabricmc.net/",
-    "sources": "https://github.com/FabricMC/fabric-example-mod"
+    "homepage": "https://github.com/edward3h/worn-path",
+    "sources": "https://github.com/edward3h/worn-path"
   },
-  "license": "CC0-1.0",
+  "license": "MIT",
   "icon": "assets/worn_path/icon.png",
   "environment": "*",
   "entrypoints": {
@@ -32,7 +32,5 @@
     "architectury": ">=18.0.6",
     "fabric-api": "*"
   },
-  "suggests": {
-    "another-mod": "*"
-  }
+  "suggests": {}
 }

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,15 +1,15 @@
 modLoader = "javafml"
 loaderVersion = "[10,)"
 #issueTrackerURL = ""
-license = "Insert License Here"
+license = "MIT"
 
 [[mods]]
 modId = "worn_path"
 version = "${version}"
 displayName = "Worn Path"
-authors = "Me!"
+authors = "edward3h"
 description = '''
-This is an example description! Tell everyone what your mod is about!
+Where players walk, paths may appear.
 '''
 #logoFile = ""
 


### PR DESCRIPTION
## Summary
- Add MIT licence file
- Update licence references in `fabric.mod.json` and `neoforge.mods.toml`
- Fix placeholder metadata (homepage, sources, authors, description) in mod files
- Expand `README.md` with "For Players" and "For Developers" sections
- Add `CONTRIBUTING.md` with build instructions and code conventions

## Test plan
- [x] `./gradlew build` passes
- [ ] Review rendered markdown on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)