### PR TITLE
Clean up BlockMixin dead code and fix Level handler leak

### DIFF
--- a/common/src/main/java/red/ethel/minecraft/wornpath/StepHandler.java
+++ b/common/src/main/java/red/ethel/minecraft/wornpath/StepHandler.java
@@ -5,7 +5,6 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
@@ -29,9 +28,9 @@ public class StepHandler {
         this.level = level;
         stepCounts = Caffeine.newBuilder()
                 .maximumSize(1000)
-                .evictionListener((k, v, cause) -> WornPathMod.LOGGER.info("evict {} {}", k, v))
+                .evictionListener((k, v, cause) -> WornPathMod.LOGGER.debug("evict {} {}", k, v))
                 .build(k -> new AtomicInteger());
-        WornPathMod.LOGGER.info("new StepHandler {} {}", level, level.getRandom());
+        WornPathMod.LOGGER.debug("new StepHandler {} {}", level, level.getRandom());
     }
 
     public void handle(Player playerEntity, BlockPos pos, BlockState state) {
@@ -56,6 +55,6 @@ public class StepHandler {
     }
 
     private int inc(String blockId, BlockPos pos) {
-        return stepCounts.get(new BlockKey(blockId, pos)).incrementAndGet();
+        return Objects.requireNonNull(stepCounts.get(new BlockKey(blockId, pos))).incrementAndGet();
     }
 }

--- a/common/src/main/java/red/ethel/minecraft/wornpath/WornPathMod.java
+++ b/common/src/main/java/red/ethel/minecraft/wornpath/WornPathMod.java
@@ -1,5 +1,6 @@
 package red.ethel.minecraft.wornpath;
 
+import dev.architectury.event.events.common.LifecycleEvent;
 import net.minecraft.world.level.Level;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,7 +15,8 @@ public final class WornPathMod {
     private static final Map<Level, StepHandler> handlers = new IdentityHashMap<>();
 
     public static void init() {
-        LOGGER.info("Hello from WornPathMod");
+        LOGGER.debug("WornPathMod initialising");
+        LifecycleEvent.SERVER_LEVEL_UNLOAD.register(handlers::remove);
     }
 
     public static StepHandler getHandler(Level level) {

--- a/common/src/main/java/red/ethel/minecraft/wornpath/mixin/BlockMixin.java
+++ b/common/src/main/java/red/ethel/minecraft/wornpath/mixin/BlockMixin.java
@@ -3,27 +3,19 @@ package red.ethel.minecraft.wornpath.mixin;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import red.ethel.minecraft.wornpath.WornPathMod;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 @Mixin({Block.class})
 public class BlockMixin {
-
-    @Unique
-    private final Map<ServerPlayer, BlockPos> lastPos = new ConcurrentHashMap<>();
 
     @Inject(at = @At("HEAD"), method = "stepOn")
     public void stepOn(Level level, BlockPos pos, BlockState state, Entity entity, CallbackInfo ci) {


### PR DESCRIPTION
## Summary
- Remove unused `lastPos` field and related imports from `BlockMixin` (tracking already lives in `StepHandler`)
- Register a `SERVER_LEVEL_UNLOAD` listener to remove `StepHandler` instances when levels unload, preventing the `IdentityHashMap` from growing indefinitely
- Reduce noisy logging in `StepHandler` to DEBUG level

## Test plan
- [ ] Build passes (`./gradlew build`)
- [ ] Load into a test world, walk around to confirm path creation still works
- [ ] Unload/reload a dimension and verify no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)