### PR TITLE
Fix player getting stuck on dirt_path to packed_mud transition

### DIFF
--- a/common/src/main/java/red/ethel/minecraft/wornpath/StepHandler.java
+++ b/common/src/main/java/red/ethel/minecraft/wornpath/StepHandler.java
@@ -48,9 +48,16 @@ public class StepHandler {
         int stepCount = inc(blockId, pos);
         if (stepCount >= WornPathBlocks.MAX_STEPS) {
             var nextId = TRANSITIONS.get(blockId);
-                        BlockState newState = BuiltInRegistries.BLOCK.getValue(ResourceLocation.parse(nextId)).defaultBlockState();
-                        WornPathMod.LOGGER.info("Block {} new {}", blockId, newState);
-                        level.setBlockAndUpdate(pos, newState);
+            BlockState newState = BuiltInRegistries.BLOCK.getValue(ResourceLocation.parse(nextId)).defaultBlockState();
+            WornPathMod.LOGGER.info("Block {} new {}", blockId, newState);
+
+            double oldHeight = state.getCollisionShape(level, pos).max(net.minecraft.core.Direction.Axis.Y);
+            double newHeight = newState.getCollisionShape(level, pos).max(net.minecraft.core.Direction.Axis.Y);
+            level.setBlockAndUpdate(pos, newState);
+
+            if (newHeight > oldHeight) {
+                playerEntity.teleportTo(playerEntity.getX(), playerEntity.getY() + (newHeight - oldHeight), playerEntity.getZ());
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- When `dirt_path` (15/16 height) transitions to `packed_mud` (full block), the player's feet end up inside the new taller block, causing them to get stuck
- Compare collision shape heights before and after the transition, and teleport the player up by the difference if the new block is taller
- Also fixes indentation in the transition block

## Test plan
- [ ] Walk on `dirt_path` blocks until one transitions to `packed_mud`
- [ ] Confirm the player is not stuck and can continue moving normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)