### PR TITLE
Add recursive neighbour spread on block transition

### DIFF
--- a/common/src/main/java/red/ethel/minecraft/wornpath/WornPathBlocks.java
+++ b/common/src/main/java/red/ethel/minecraft/wornpath/WornPathBlocks.java
@@ -5,6 +5,7 @@ import java.util.Map;
 public class WornPathBlocks {
     public static final int STEP_RANDOMNESS = 3;
     public static final int MAX_STEPS = 3;
+    public static final int MAX_SPREAD_DEPTH = 2;
     public static final Map<String, String> TRANSITIONS = Map.of(
             "minecraft:grass_block", "minecraft:dirt_path",
             "minecraft:dirt", "minecraft:dirt_path",


### PR DESCRIPTION
## Summary
- When a block transitions, horizontally adjacent blocks with sufficient step counts also transition recursively
- Recursion depth controlled by `MAX_SPREAD_DEPTH` constant (default 2)
- Neighbour transitions bypass the `lastPos` and randomness checks
- Player teleport logic only applies to the block the player is standing on (depth 0)

## Test plan
- [ ] `./gradlew build` passes
- [ ] Walk on a cluster of same-type blocks; when one transitions, neighbours with sufficient step counts should also transition
- [ ] Verify recursion stops at configured depth (check log messages for depth values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)