### PR TITLE
Update to Minecraft 1.21.11

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Worn Path Minecraft Mod
 
-Architectury-based multi-platform Minecraft mod for Fabric and NeoForge (MC 1.21.10).
+Architectury-based multi-platform Minecraft mod for Fabric and NeoForge (MC 1.21.11).
 Where players walk, paths may appear.
 
 ## Build Commands
@@ -33,13 +33,13 @@ Platform-agnostic logic goes in `common`. Each platform subproject has a thin en
 
 | Dependency | Version |
 |---|---|
-| Minecraft | 1.21.10 |
+| Minecraft | 1.21.11 |
 | Fabric Loader | 0.18.4+ |
-| Fabric API | 0.138.4+1.21.10 |
-| NeoForge | 21.10.34-beta |
-| Architectury API | 18.0.6+ |
+| Fabric API | 0.141.3+1.21.11 |
+| NeoForge | 21.11.38-beta |
+| Architectury API | 19.0.1+ |
 | Caffeine (caching) | 3.2.0 |
-| Parchment mappings | 2025.10.12 |
+| Parchment mappings | 2025.12.20 |
 
 ## Mixins
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ subprojects {
         minecraft "net.minecraft:minecraft:$rootProject.minecraft_version"
         mappings loom.layered() {
             officialMojangMappings()
-            parchment("org.parchmentmc.data:parchment-${rootProject.minecraft_version}:2025.10.12@zip")
+            parchment("org.parchmentmc.data:parchment-${rootProject.minecraft_version}:2025.12.20@zip")
         }
         implementation("org.slf4j:slf4j-api:2.0.17")
         implementation("com.github.ben-manes.caffeine:caffeine:3.2.3")

--- a/common/src/main/java/red/ethel/minecraft/wornpath/StepHandler.java
+++ b/common/src/main/java/red/ethel/minecraft/wornpath/StepHandler.java
@@ -4,7 +4,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
@@ -52,7 +52,7 @@ public class StepHandler {
         int stepCount = inc(blockId, pos);
         if (stepCount >= WornPathConfigManager.getMaxSteps()) {
             var nextId = transitions.get(blockId);
-            BlockState newState = BuiltInRegistries.BLOCK.getValue(ResourceLocation.parse(nextId)).defaultBlockState();
+            BlockState newState = BuiltInRegistries.BLOCK.getValue(Identifier.parse(nextId)).defaultBlockState();
             WornPathMod.LOGGER.info("Transitioning {} to {} at depth {}", blockId, newState, depth);
 
             if (depth == 0) {

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -30,9 +30,9 @@
   ],
   "depends": {
     "fabricloader": ">=0.18.4",
-    "minecraft": "~1.21.10",
+    "minecraft": "~1.21.11",
     "java": ">=21",
-    "architectury": ">=18.0.6",
+    "architectury": ">=19.0.1",
     "fabric-api": "*"
   },
   "suggests": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,16 +9,16 @@ archives_name = worn_path
 enabled_platforms = fabric,neoforge
 
 # Minecraft properties
-minecraft_version = 1.21.10
+minecraft_version = 1.21.11
 
 # Dependencies
-architectury_api_version = 18.0.6
+architectury_api_version = 19.0.1
 fabric_loader_version = 0.18.4
-fabric_api_version = 0.138.4+1.21.10
-neoforge_version = 21.10.34-beta
+fabric_api_version = 0.141.3+1.21.11
+neoforge_version = 21.11.38-beta
 
 # Config dependencies
-yacl_version = 3.8.1+1.21.10-fabric
-yacl_version_neoforge = 3.8.1+1.21.10-neoforge
-modmenu_version = 16.0.0
+yacl_version = 3.8.1+1.21.11-fabric
+yacl_version_neoforge = 3.8.1+1.21.11-neoforge
+modmenu_version = 17.0.0-beta.2
 jankson_version = 1.2.3

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -16,21 +16,21 @@ Where players walk, paths may appear.
 [[dependencies.worn_path]]
 modId = "neoforge"
 type = "required"
-versionRange = "[21.10,)"
+versionRange = "[21.11,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.worn_path]]
 modId = "minecraft"
 type = "required"
-versionRange = "[1.21.10,)"
+versionRange = "[1.21.11,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.worn_path]]
 modId = "architectury"
 type = "required"
-versionRange = "[18.0.6,)"
+versionRange = "[19.0.1,)"
 ordering = "AFTER"
 side = "BOTH"
 


### PR DESCRIPTION
## Summary
- Bump all dependency versions to target Minecraft 1.21.11 (Fabric API, NeoForge, Architectury, YACL, ModMenu, Parchment)
- Fix `ResourceLocation` → `Identifier` rename in MC 1.21.11 API
- Update CLAUDE.md to reflect new versions

## Test plan
- [x] `./gradlew clean build` compiles successfully for both Fabric and NeoForge
- [ ] Test in-game on Fabric with MC 1.21.11
- [ ] Test in-game on NeoForge with MC 1.21.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)