### PR TITLE
Add mod-publish-plugin for Modrinth publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'dev.architectury.loom' version '1.13.467' apply false
     id 'architectury-plugin' version '3.4.162'
     id 'com.gradleup.shadow' version '8.3.9' apply false
+    id 'me.modmuss50.mod-publish-plugin' version '1.1.0' apply false
 }
 
 architectury {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.gradleup.shadow'
+    id 'me.modmuss50.mod-publish-plugin'
 }
 
 architectury {
@@ -58,4 +59,20 @@ shadowJar {
 
 remapJar {
     inputFile.set shadowJar.archiveFile
+}
+
+publishMods {
+    file = remapJar.archiveFile
+    type = STABLE
+    modLoaders.add("fabric")
+
+    modrinth {
+        accessToken = providers.environmentVariable("MODRINTH_TOKEN")
+        projectId = rootProject.modrinth_project_id
+        minecraftVersions.add(rootProject.minecraft_version)
+        requires("architectury-api")
+        requires("fabric-api")
+        optional("yet-another-config-lib")
+        optional("modmenu")
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,6 @@ yacl_version = 3.8.1+1.21.11-fabric
 yacl_version_neoforge = 3.8.1+1.21.11-neoforge
 modmenu_version = 17.0.0-beta.2
 jankson_version = 1.2.3
+
+# Publishing
+modrinth_project_id = 3XWY8ZZP

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.gradleup.shadow'
+    id 'me.modmuss50.mod-publish-plugin'
 }
 
 architectury {
@@ -61,4 +62,18 @@ shadowJar {
 
 remapJar {
     inputFile.set shadowJar.archiveFile
+}
+
+publishMods {
+    file = remapJar.archiveFile
+    type = STABLE
+    modLoaders.add("neoforge")
+
+    modrinth {
+        accessToken = providers.environmentVariable("MODRINTH_TOKEN")
+        projectId = rootProject.modrinth_project_id
+        minecraftVersions.add(rootProject.minecraft_version)
+        requires("architectury-api")
+        optional("yet-another-config-lib")
+    }
 }


### PR DESCRIPTION
## Summary
- Integrate [mod-publish-plugin](https://github.com/modmuss50/mod-publish-plugin) v1.1.0 to automate uploading release JARs to Modrinth
- Configure `publishMods` blocks for both Fabric and NeoForge subprojects with appropriate dependency declarations
- Add `modrinth_project_id` to `gradle.properties`

## Usage
```bash
MODRINTH_TOKEN="your-token" ./gradlew publishMods
```

## Test plan
- [x] `./gradlew build` passes with the new plugin applied
- [ ] Verify `publishMods` task appears in Gradle task list
- [ ] Test publishing with a valid Modrinth PAT (requires `VERSION_CREATE` scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)