### PR TITLE
Add required changelog property to publishMods config

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -63,6 +63,7 @@ remapJar {
 
 publishMods {
     file = remapJar.archiveFile
+    changelog = providers.environmentVariable("CHANGELOG").orElse("Release ${project.version}")
     type = STABLE
     modLoaders.add("fabric")
 

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -66,6 +66,7 @@ remapJar {
 
 publishMods {
     file = remapJar.archiveFile
+    changelog = providers.environmentVariable("CHANGELOG").orElse("Release ${project.version}")
     type = STABLE
     modLoaders.add("neoforge")
 


### PR DESCRIPTION
## Summary
- Add the required `changelog` property to `publishMods` blocks in both Fabric and NeoForge build files
- Reads from `CHANGELOG` environment variable, falling back to `"Release <version>"`

## Test plan
- [x] `./gradlew build` passes without validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)