### PR TITLE
Fix YACL Modrinth slug in publishMods config

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -73,7 +73,7 @@ publishMods {
         minecraftVersions.add(rootProject.minecraft_version)
         requires("architectury-api")
         requires("fabric-api")
-        optional("yet-another-config-lib")
+        optional("yacl")
         optional("modmenu")
     }
 }

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -75,6 +75,6 @@ publishMods {
         projectId = rootProject.modrinth_project_id
         minecraftVersions.add(rootProject.minecraft_version)
         requires("architectury-api")
-        optional("yet-another-config-lib")
+        optional("yacl")
     }
 }


### PR DESCRIPTION
## Summary
- Fix the Modrinth project slug for YACL: `"yacl"` instead of `"yet-another-config-lib"`
- The old slug returned a 404 from the Modrinth API during publishing

## Test plan
- [ ] `./gradlew publishMods` no longer fails with a 404 for the YACL dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)