### PR TITLE
Bundle Caffeine in platform JARs and bump to 1.0.1

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     // Architectury API. This is optional, and you can comment it out if you don't need it.
     modImplementation "dev.architectury:architectury:$rootProject.architectury_api_version"
 
-    modImplementation("com.github.ben-manes.caffeine:caffeine:3.2.3")
+    modImplementation("com.github.ben-manes.caffeine:caffeine:$rootProject.caffeine_version")
 
     // Jankson for config file parsing
     implementation "blue.endless:jankson:$rootProject.jankson_version"

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     shadowBundle project(path: ':common', configuration: 'transformProductionFabric')
     shadowBundle "blue.endless:jankson:$rootProject.jankson_version"
     runtimeOnly "blue.endless:jankson:$rootProject.jankson_version"
+    shadowBundle "com.github.ben-manes.caffeine:caffeine:$rootProject.caffeine_version"
+    runtimeOnly "com.github.ben-manes.caffeine:caffeine:$rootProject.caffeine_version"
 
     // Config dependencies (optional at runtime)
     modImplementation "dev.isxander:yet-another-config-lib:$rootProject.yacl_version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Mod properties
-mod_version = 1.0.0
+mod_version = 1.0.1
 maven_group = red.ethel.minecraft.wornpath
 archives_name = worn_path
 enabled_platforms = fabric,neoforge
@@ -22,6 +22,7 @@ yacl_version = 3.8.1+1.21.11-fabric
 yacl_version_neoforge = 3.8.1+1.21.11-neoforge
 modmenu_version = 17.0.0-beta.2
 jankson_version = 1.2.3
+caffeine_version = 3.2.3
 
 # Publishing
 modrinth_project_id = 3XWY8ZZP

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     shadowBundle project(path: ':common', configuration: 'transformProductionNeoForge')
     shadowBundle "blue.endless:jankson:$rootProject.jankson_version"
     runtimeOnly "blue.endless:jankson:$rootProject.jankson_version"
+    shadowBundle "com.github.ben-manes.caffeine:caffeine:$rootProject.caffeine_version"
+    runtimeOnly "com.github.ben-manes.caffeine:caffeine:$rootProject.caffeine_version"
 
     // Config dependency (optional at runtime)
     modImplementation "dev.isxander:yet-another-config-lib:$rootProject.yacl_version_neoforge"


### PR DESCRIPTION
## Summary
- Add Caffeine to `shadowBundle` and `runtimeOnly` in both Fabric and NeoForge builds, fixing `NoClassDefFoundError` at runtime
- Extract Caffeine version to `gradle.properties` for consistency with other dependencies
- Bump mod version to 1.0.1

## Test plan
- [ ] Verify Caffeine classes are present in the built JARs
- [ ] Confirm no `NoClassDefFoundError` when stepping on blocks in-game

🤖 Generated with [Claude Code](https://claude.com/claude-code)