### PR TITLE
Add mod description file and sync to Modrinth

### DIFF
--- a/description.md
+++ b/description.md
@@ -1,0 +1,13 @@
+A server side mod. Tracks where players walk, and if they walk over the same block enough times, it will be converted to a different block.
+
+With the default settings, grass or dirt get converted to dirt path, dirt path or coarse dirt to packed mud, packed mud to mud bricks.
+
+## Configuration
+
+Settings can be changed by editing `config/worn_path.json5`.
+This file is generated after the mod has been initialized for the first time.
+Comments in the file explain the settings.
+
+### YACL
+
+If YACL is available, it can be used in the client to configure some of the settings for a single player world.

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -72,6 +72,7 @@ publishMods {
     modrinth {
         accessToken = env.fetchOrNull("MODRINTH_TOKEN")
         projectId = rootProject.modrinth_project_id
+        projectDescription = rootProject.file("description.md").text
         minecraftVersions.add(rootProject.minecraft_version)
         requires("architectury-api")
         requires("fabric-api")

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -75,6 +75,7 @@ publishMods {
     modrinth {
         accessToken = env.fetchOrNull("MODRINTH_TOKEN")
         projectId = rootProject.modrinth_project_id
+        projectDescription = rootProject.file("description.md").text
         minecraftVersions.add(rootProject.minecraft_version)
         requires("architectury-api")
         optional("yacl")


### PR DESCRIPTION
## Summary

- Add `description.md` with the mod description for use across distribution sites
- Configure `publishMods` to update the Modrinth project description automatically when publishing

## Test plan

- [x] `./gradlew build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)