### PR TITLE
Prevent block conversion when a block is above it

### DIFF
--- a/common/src/main/java/red/ethel/minecraft/wornpath/StepHandler.java
+++ b/common/src/main/java/red/ethel/minecraft/wornpath/StepHandler.java
@@ -51,6 +51,9 @@ public class StepHandler {
         }
         int stepCount = inc(blockId, pos);
         if (stepCount >= WornPathConfigManager.getMaxSteps()) {
+            if (!level.getBlockState(pos.above()).isAir()) {
+                return;
+            }
             var nextId = transitions.get(blockId);
             BlockState newState = BuiltInRegistries.BLOCK.getValue(Identifier.parse(nextId)).defaultBlockState();
             WornPathMod.LOGGER.info("Transitioning {} to {} at depth {}", blockId, newState, depth);


### PR DESCRIPTION
## Summary

- Fixes #39
- Before converting a block, check that the space directly above is air
- Prevents spreading from converting covered blocks (e.g. inside tunnels or under roofs)
- Applies at all depths — both direct player stepping and spread transitions

## Test plan

- [ ] Walk on a grass block with a block placed on top — it should not convert
- [ ] Walk on a normal open grass block — it should still convert as before
- [ ] Verify spreading does not convert covered neighbours

🤖 Generated with [Claude Code](https://claude.com/claude-code)