### PR TITLE
Add sheep farm protection (fixes #38)

### DIFF
--- a/common/src/main/java/red/ethel/minecraft/wornpath/StepHandler.java
+++ b/common/src/main/java/red/ethel/minecraft/wornpath/StepHandler.java
@@ -5,8 +5,10 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.animal.sheep.Sheep;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 import red.ethel.minecraft.wornpath.config.WornPathConfigManager;
@@ -52,6 +54,10 @@ public class StepHandler {
         int stepCount = inc(blockId, pos);
         if (stepCount >= WornPathConfigManager.getMaxSteps()) {
             if (!level.getBlockState(pos.above()).isAir()) {
+                return;
+            }
+            int sheepRadius = WornPathConfigManager.getSheepProtectionRadius();
+            if (sheepRadius > 0 && !level.getEntitiesOfClass(Sheep.class, new AABB(pos).inflate(sheepRadius)).isEmpty()) {
                 return;
             }
             var nextId = transitions.get(blockId);

--- a/common/src/main/java/red/ethel/minecraft/wornpath/config/WornPathConfig.java
+++ b/common/src/main/java/red/ethel/minecraft/wornpath/config/WornPathConfig.java
@@ -10,6 +10,7 @@ public class WornPathConfig {
     public int stepChance = 4;
     public int maxSteps = 3;
     public int maxSpreadDepth = 2;
+    public int sheepProtectionRadius = 2;
     public Map<String, String> transitions = defaultTransitions();
 
     private static Map<String, String> defaultTransitions() {

--- a/common/src/main/java/red/ethel/minecraft/wornpath/config/WornPathConfigManager.java
+++ b/common/src/main/java/red/ethel/minecraft/wornpath/config/WornPathConfigManager.java
@@ -91,6 +91,9 @@ public class WornPathConfigManager {
         if (json.containsKey("maxSpreadDepth")) {
             cfg.maxSpreadDepth = json.getInt("maxSpreadDepth", cfg.maxSpreadDepth);
         }
+        if (json.containsKey("sheepProtectionRadius")) {
+            cfg.sheepProtectionRadius = json.getInt("sheepProtectionRadius", cfg.sheepProtectionRadius);
+        }
         if (json.containsKey("transitions")) {
             JsonObject obj = (JsonObject) json.get("transitions");
             if (obj != null) {
@@ -115,6 +118,8 @@ public class WornPathConfigManager {
         json.setComment("maxSteps", "Steps needed to trigger block transition");
         json.put("maxSpreadDepth", JsonPrimitive.of((long) cfg.maxSpreadDepth));
         json.setComment("maxSpreadDepth", "How far transitions spread to neighbours (0 = no spread)");
+        json.put("sheepProtectionRadius", JsonPrimitive.of((long) cfg.sheepProtectionRadius));
+        json.setComment("sheepProtectionRadius", "Radius in blocks around a block within which sheep prevent conversion (0 = disabled)");
 
         JsonObject transitions = new JsonObject();
         for (var entry : cfg.transitions.entrySet()) {
@@ -160,6 +165,10 @@ public class WornPathConfigManager {
 
     public static int getMaxSpreadDepth() {
         return getConfig().maxSpreadDepth;
+    }
+
+    public static int getSheepProtectionRadius() {
+        return getConfig().sheepProtectionRadius;
     }
 
     public static Map<String, String> getTransitions() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Mod properties
-mod_version = 1.1.1
+mod_version = 1.2.0
 maven_group = red.ethel.minecraft.wornpath
 archives_name = worn_path
 enabled_platforms = fabric,neoforge


### PR DESCRIPTION
## Summary

- Adds a `sheepProtectionRadius` config option (default: 2 blocks, 0 = disabled) that prevents grass block conversion when a sheep is within range
- Implements the check in `StepHandler.tryTransition()` after the existing air-block guard
- Bumps version to 1.2.0

## Test plan

- [ ] Place a sheep within 2 blocks of a grass block; walk over it many times — it should not convert
- [ ] Move the sheep more than 2 blocks away; walk over the grass again — it should convert normally
- [ ] Set `sheepProtectionRadius = 0` in `worn_path.json5` and confirm sheep no longer inhibit conversion
- [ ] Verify dirt blocks in sheep-free areas still convert normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)