### PR TITLE
Fix GitHub release tag always using 'vunspecified'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ publishMods {
         accessToken = env.fetchOrNull("GITHUB_TOKEN")
         repository = github_repo
         commitish = "main"
-        tagName = "v${project.version}"
+        tagName = "v${project.mod_version}"
         allowEmptyFiles = true
     }
 }


### PR DESCRIPTION
## Summary

- `project.version` is not resolved when the `publishMods` block is configured, so `tagName = "v${project.version}"` always evaluates to `"vunspecified"`
- Fixes by referencing `project.mod_version` (the gradle.properties key) directly, which is available immediately as a project property

## Impact

- The draft 1.2.0 release with the wrong tag has been deleted
- After merging, re-running `publishGithub` will create a release tagged `v1.2.0` as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)