### PR TITLE
Allow block conversion when a passable block is overhead

### DIFF
--- a/common/src/main/java/red/ethel/minecraft/wornpath/StepHandler.java
+++ b/common/src/main/java/red/ethel/minecraft/wornpath/StepHandler.java
@@ -4,11 +4,14 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.animal.sheep.Sheep;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 import red.ethel.minecraft.wornpath.config.WornPathConfigManager;
@@ -53,7 +56,8 @@ public class StepHandler {
         }
         int stepCount = inc(blockId, pos);
         if (stepCount >= WornPathConfigManager.getMaxSteps()) {
-            if (!level.getBlockState(pos.above()).isAir()) {
+            BlockState aboveState = level.getBlockState(pos.above());
+            if (!aboveState.isAir() && !isPassableOverhead(aboveState)) {
                 return;
             }
             int sheepRadius = WornPathConfigManager.getSheepProtectionRadius();
@@ -82,6 +86,16 @@ public class StepHandler {
                 }
             }
         }
+    }
+
+    private boolean isPassableOverhead(BlockState state) {
+        for (String tagId : WornPathConfigManager.getOverheadPassableTags()) {
+            TagKey<Block> tag = TagKey.create(Registries.BLOCK, Identifier.parse(tagId));
+            if (state.is(tag)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private int inc(String blockId, BlockPos pos) {

--- a/common/src/main/java/red/ethel/minecraft/wornpath/config/WornPathConfig.java
+++ b/common/src/main/java/red/ethel/minecraft/wornpath/config/WornPathConfig.java
@@ -1,6 +1,8 @@
 package red.ethel.minecraft.wornpath.config;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -12,6 +14,11 @@ public class WornPathConfig {
     public int maxSpreadDepth = 2;
     public int sheepProtectionRadius = 2;
     public Map<String, String> transitions = defaultTransitions();
+    public List<String> overheadPassableTags = defaultOverheadPassableTags();
+
+    private static List<String> defaultOverheadPassableTags() {
+        return new ArrayList<>(List.of("minecraft:replaceable", "minecraft:flowers"));
+    }
 
     private static Map<String, String> defaultTransitions() {
         var map = new LinkedHashMap<String, String>();

--- a/common/src/main/java/red/ethel/minecraft/wornpath/config/WornPathConfigManager.java
+++ b/common/src/main/java/red/ethel/minecraft/wornpath/config/WornPathConfigManager.java
@@ -1,6 +1,7 @@
 package red.ethel.minecraft.wornpath.config;
 
 import blue.endless.jankson.Jankson;
+import blue.endless.jankson.JsonArray;
 import blue.endless.jankson.JsonObject;
 import blue.endless.jankson.JsonPrimitive;
 import blue.endless.jankson.api.SyntaxError;
@@ -9,7 +10,9 @@ import red.ethel.minecraft.wornpath.WornPathMod;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -106,6 +109,17 @@ public class WornPathConfigManager {
                 cfg.transitions = map;
             }
         }
+        if (json.containsKey("overheadPassableTags")) {
+            if (json.get("overheadPassableTags") instanceof JsonArray arr) {
+                List<String> tags = new ArrayList<>();
+                for (var element : arr) {
+                    if (element instanceof JsonPrimitive primitive) {
+                        tags.add(primitive.asString());
+                    }
+                }
+                cfg.overheadPassableTags = tags;
+            }
+        }
 
         return cfg;
     }
@@ -127,6 +141,13 @@ public class WornPathConfigManager {
         }
         json.put("transitions", transitions);
         json.setComment("transitions", "Block transitions: source block ID -> target block ID");
+
+        JsonArray tagsArray = new JsonArray();
+        for (String tag : cfg.overheadPassableTags) {
+            tagsArray.add(JsonPrimitive.of(tag));
+        }
+        json.put("overheadPassableTags", tagsArray);
+        json.setComment("overheadPassableTags", "Block tags treated as passable overhead — conversion is still allowed when a matching block is above");
 
         return json;
     }
@@ -173,5 +194,9 @@ public class WornPathConfigManager {
 
     public static Map<String, String> getTransitions() {
         return getConfig().transitions;
+    }
+
+    public static List<String> getOverheadPassableTags() {
+        return getConfig().overheadPassableTags;
     }
 }

--- a/description.md
+++ b/description.md
@@ -2,6 +2,8 @@ A server side mod. Tracks where players walk, and if they walk over the same blo
 
 With the default settings, grass or dirt get converted to dirt path, dirt path or coarse dirt to packed mud, packed mud to mud bricks.
 
+Conversion is prevented when a solid block is directly overhead (plants and flowers overhead are allowed), or when sheep are grazing nearby (configurable radius, 2 blocks by default).
+
 ## Configuration
 
 Settings can be changed by editing `config/worn_path.json5`.


### PR DESCRIPTION
## Summary

- Relaxes the overhead block check introduced in #41 so that plants and flowers above a block no longer prevent path conversion
- The set of block tags treated as passable overhead is now configurable via `overheadPassableTags` in `worn_path.json5` (defaults: `minecraft:replaceable`, `minecraft:flowers`)
- Updates `description.md` to document the conditions that prevent conversion

## Test plan

- [ ] Walk on grass_block with nothing above → converts as before
- [ ] Walk on grass_block with short_grass above → should now convert
- [ ] Walk on grass_block with a flower above → should now convert
- [ ] Walk on grass_block under a solid roof → should still NOT convert
- [ ] Walk on grass_block underwater → should still NOT convert
- [ ] Remove a tag from `overheadPassableTags` in config → that block type should now block conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)