### PR TITLE
Add GitHub bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,42 @@
+name: Bug Report
+description: Report a problem with Worn Path
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: input
+    id: mc-version
+    attributes:
+      label: Minecraft Version
+      placeholder: e.g. 1.21.11
+    validations:
+      required: true
+
+  - type: input
+    id: mod-version
+    attributes:
+      label: Worn Path Version
+      placeholder: e.g. 1.3.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mod-loader
+    attributes:
+      label: Mod Loader
+      options:
+        - Fabric
+        - NeoForge
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect to happen?
+    validations:
+      required: true


### PR DESCRIPTION
## Summary

- Adds a structured YAML issue form template for bug reports
- Requires Minecraft version, Worn Path version, and mod loader (Fabric/NeoForge) before submission
- Labels new bug reports automatically with `bug`

## Test plan

- [ ] Open a new issue on GitHub and confirm the template appears as an option
- [ ] Verify the three required fields block submission if left empty
- [ ] Confirm the mod loader dropdown shows Fabric and NeoForge

🤖 Generated with [Claude Code](https://claude.com/claude-code)