### PR TITLE
Update to Minecraft 26.1.2 and multi-version branch strategy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,13 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'mc/**'
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'mc/**'
 
 jobs:
   build:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,3 @@
-java temurin-21.0.10+7.0.LTS
+# MC 26.1 requires Java 25.
+# Run `asdf list all java | grep temurin-25` to find the correct version string, then update this file.
+java temurin-25.0.0+36.0.LTS

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,3 @@
-java temurin-21.0.11+10.0.LTS
+# MC 26.1 requires Java 25.
+# Run `asdf list all java | grep temurin-25` to find the correct version string, then update this file.
+java temurin-25.0.0+36.0.LTS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,23 +44,32 @@ Platform-agnostic logic goes in `common`. Each platform subproject has a thin en
   - Platform-specific: `.fabric`, `.neoforge`
   - Mixins: `.mixin`
 - **Mod ID**: `worn_path`
-- **Java**: 21, standard conventions
+- **Java**: 25, standard conventions
 - No automated code style enforcement currently configured
 
-## Key Dependencies
+## Key Dependencies (MC 26.1.2 / `main` branch)
 
 | Dependency | Version |
 |---|---|
-| Minecraft | 1.21.11 |
+| Minecraft | 26.1.2 |
 | Fabric Loader | 0.18.4+ |
-| Fabric API | 0.141.3+1.21.11 |
-| NeoForge | 21.11.38-beta |
-| Architectury API | 19.0.1+ |
-| Caffeine (caching) | 3.2.0 |
-| Parchment mappings | 2025.12.20 |
+| Fabric API | 0.146.0+26.1.2 |
+| NeoForge | 26.1.2.10-beta |
+| Architectury API | pending — not yet released for MC 26.1 |
+| Caffeine (caching) | 3.2.3 |
+
+> **Note**: MC 26.1 removed obfuscation — Parchment mappings are no longer needed. Official Mojang mappings now include parameter names.
+
+## MC 26.1 API Changes
+
+Notable changes that may require code fixes when porting:
+
+- `ItemStack` can no longer be created until a world is loaded — use `ItemStackTemplate` instead
+- `GuiGraphics` renamed to `GuiGraphicsExtractor`; `Screen#render` became `Screen#extractRenderState`
+- `ColorProviderRegistry.BLOCK` replaced with `BlockColorRegistry`
 
 ## Mixins
 
 Config: `common/src/main/resources/worn_path.mixins.json`
 Package: `red.ethel.minecraft.wornpath.mixin`
-Compatibility level: JAVA_21
+Compatibility level: JAVA_25

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,32 @@
 # Worn Path Minecraft Mod
 
-Architectury-based multi-platform Minecraft mod for Fabric and NeoForge (MC 1.21.11).
+Architectury-based multi-platform Minecraft mod for Fabric and NeoForge.
 Where players walk, paths may appear.
+
+## Multi-Version Branch Strategy
+
+Each Minecraft version has its own branch:
+
+| Branch | Minecraft version |
+|---|---|
+| `main` | latest supported MC version |
+| `mc/1.21.11` | MC 1.21.11 |
+
+Bug fixes and features are developed on one branch and cherry-picked to others. Each branch has its own `gradle.properties` with the correct dependency versions. Published artefacts include the MC version in the version string (e.g. `1.5.1+1.21.11`).
+
+To port a commit to another MC version:
+```
+git cherry-pick <commit-hash>
+# fix any MC API incompatibilities
+git push
+```
 
 ## Build Commands
 
 - `./gradlew build` — Build all platform variants
 - `./gradlew clean` — Clean build artefacts
 
-Java 21 required (managed via asdf, see `.tool-versions`).
+Java version required depends on the branch (see `.tool-versions`).
 
 ## Project Structure
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,14 +24,14 @@ publishMods {
         accessToken = env.fetchOrNull("GITHUB_TOKEN")
         repository = github_repo
         commitish = "main"
-        tagName = "v${project.mod_version}"
+        tagName = "v${project.version}"
         allowEmptyFiles = true
     }
 }
 
 allprojects {
     group = rootProject.maven_group
-    version = rootProject.mod_version
+    version = "${rootProject.mod_version}+${rootProject.minecraft_version}"
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,6 @@ allprojects {
 
     repositories {
         maven {
-            name = "ParchmentMC"
-            url = "https://maven.parchmentmc.org"
-        }
-        maven {
             name = "Xander Maven"
             url = "https://maven.isxander.dev/releases"
         }
@@ -77,10 +73,8 @@ subprojects {
 
     dependencies {
         minecraft "net.minecraft:minecraft:$rootProject.minecraft_version"
-        mappings loom.layered() {
-            officialMojangMappings()
-            parchment("org.parchmentmc.data:parchment-${rootProject.minecraft_version}:2025.12.20@zip")
-        }
+        // MC 26.1 removed obfuscation — official mappings now include parameter names
+        mappings loom.officialMojangMappings()
         implementation("org.slf4j:slf4j-api:2.0.17")
         implementation("com.github.ben-manes.caffeine:caffeine:3.2.3")
     }
@@ -91,12 +85,12 @@ subprojects {
         // If you remove this line, sources will not be generated.
         withSourcesJar()
 
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_25
+        targetCompatibility = JavaVersion.VERSION_25
     }
 
     tasks.withType(JavaCompile).configureEach {
-        it.options.release = 21
+        it.options.release = 25
     }
 
     // Configure Maven publishing.

--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,6 @@ allprojects {
 
     repositories {
         maven {
-            name = "ParchmentMC"
-            url = "https://maven.parchmentmc.org"
-        }
-        maven {
             name = "Xander Maven"
             url = "https://maven.isxander.dev/releases"
         }
@@ -77,10 +73,8 @@ subprojects {
 
     dependencies {
         minecraft "net.minecraft:minecraft:$rootProject.minecraft_version"
-        mappings loom.layered() {
-            officialMojangMappings()
-            parchment("org.parchmentmc.data:parchment-${rootProject.minecraft_version}:2025.12.20@zip")
-        }
+        // MC 26.1 removed obfuscation — official mappings now include parameter names
+        mappings loom.officialMojangMappings()
         implementation("org.slf4j:slf4j-api:2.0.18")
         implementation("com.github.ben-manes.caffeine:caffeine:3.2.4")
     }
@@ -91,12 +85,12 @@ subprojects {
         // If you remove this line, sources will not be generated.
         withSourcesJar()
 
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_25
+        targetCompatibility = JavaVersion.VERSION_25
     }
 
     tasks.withType(JavaCompile).configureEach {
-        it.options.release = 21
+        it.options.release = 25
     }
 
     // Configure Maven publishing.

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,18 +9,20 @@ archives_name = worn_path
 enabled_platforms = fabric,neoforge
 
 # Minecraft properties
-minecraft_version = 1.21.11
+minecraft_version = 26.1.2
 
 # Dependencies
+# TODO: Architectury API has not yet released a version for MC 26.1 — build will fail until available
 architectury_api_version = 19.0.1
 fabric_loader_version = 0.18.4
-fabric_api_version = 0.141.3+1.21.11
-neoforge_version = 21.11.42
+fabric_api_version = 0.146.0+26.1.2
+neoforge_version = 26.1.2.10-beta
 
 # Config dependencies
-yacl_version = 3.8.1+1.21.11-fabric
+# TODO: verify YACL and ModMenu versions once stable releases are available for 26.1
+yacl_version = 3.9.1+26.1-fabric
 yacl_version_neoforge = 3.9.1+26.1-neoforge
-modmenu_version = 17.0.0
+modmenu_version = 18.0.0-alpha.8
 jankson_version = 1.2.3
 caffeine_version = 3.2.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,18 +9,20 @@ archives_name = worn_path
 enabled_platforms = fabric,neoforge
 
 # Minecraft properties
-minecraft_version = 1.21.11
+minecraft_version = 26.1.2
 
 # Dependencies
+# TODO: Architectury API has not yet released a version for MC 26.1 — build will fail until available
 architectury_api_version = 19.0.1
 fabric_loader_version = 0.18.4
-fabric_api_version = 0.141.3+1.21.11
-neoforge_version = 21.11.42
+fabric_api_version = 0.146.0+26.1.2
+neoforge_version = 26.1.2.10-beta
 
 # Config dependencies
-yacl_version = 3.8.1+1.21.11-fabric
+# TODO: verify YACL and ModMenu versions once stable releases are available for 26.1
+yacl_version = 3.9.1+26.1-fabric
 yacl_version_neoforge = 3.9.3+26.1-neoforge
-modmenu_version = 17.0.0
+modmenu_version = 18.0.0-alpha.8
 jankson_version = 1.2.3
 caffeine_version = 3.2.4
 


### PR DESCRIPTION
## Summary

- Sets up branch-per-version strategy: `mc/1.21.11` preserves the old version, `main` tracks the latest
- Artefacts now versioned as `<mod_version>+<mc_version>` (e.g. `1.5.1+26.1.2`) so jars are distinguishable across MC versions
- GitHub release tags updated to match (e.g. `v1.5.1+26.1.2`)
- CI now builds on `main` and all `mc/**` branches
- Updated to MC 26.1.2 dependencies: NeoForge 26.1.2.10-beta, Fabric API 0.146.0+26.1.2
- Java 21 → 25 (MC 26.1 requirement)
- Dropped Parchment mappings (MC 26.1 removed obfuscation; official Mojang mappings now include parameter names)

## Known blocker

**Architectury API has not yet released a version for MC 26.1.** The build will fail until that is available. Track progress at https://github.com/architectury/architectury-api/issues/704

## Test plan

- [ ] Verify CI triggers on `mc/1.21.11` push
- [ ] Once Architectury API releases a 26.1 build: update `architectury_api_version` in `gradle.properties` and run `./gradlew build`
- [ ] Install Java 25 via asdf and verify correct version string in `.tool-versions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)