### PR TITLE
Set up multi-version branch strategy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,13 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'mc/**'
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'mc/**'
 
 jobs:
   build:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,32 @@
 # Worn Path Minecraft Mod
 
-Architectury-based multi-platform Minecraft mod for Fabric and NeoForge (MC 1.21.11).
+Architectury-based multi-platform Minecraft mod for Fabric and NeoForge.
 Where players walk, paths may appear.
+
+## Multi-Version Branch Strategy
+
+Each Minecraft version has its own branch:
+
+| Branch | Minecraft version |
+|---|---|
+| `main` | latest supported MC version |
+| `mc/1.21.11` | MC 1.21.11 |
+
+Bug fixes and features are developed on one branch and cherry-picked to others. Each branch has its own `gradle.properties` with the correct dependency versions. Published artefacts include the MC version in the version string (e.g. `1.5.1+1.21.11`).
+
+To port a commit to another MC version:
+```
+git cherry-pick <commit-hash>
+# fix any MC API incompatibilities
+git push
+```
 
 ## Build Commands
 
 - `./gradlew build` — Build all platform variants
 - `./gradlew clean` — Clean build artefacts
 
-Java 21 required (managed via asdf, see `.tool-versions`).
+Java version required depends on the branch (see `.tool-versions`).
 
 ## Project Structure
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,14 +24,14 @@ publishMods {
         accessToken = env.fetchOrNull("GITHUB_TOKEN")
         repository = github_repo
         commitish = "main"
-        tagName = "v${project.mod_version}"
+        tagName = "v${project.version}"
         allowEmptyFiles = true
     }
 }
 
 allprojects {
     group = rootProject.maven_group
-    version = rootProject.mod_version
+    version = "${rootProject.mod_version}+${rootProject.minecraft_version}"
 
     repositories {
         maven {


### PR DESCRIPTION
## Summary

- Version artefacts as `mod_version+minecraft_version` (e.g. `1.5.1+1.21.11`) so published JARs are distinguishable across MC versions
- Update GitHub release tag to use the full version string
- CI now builds on `main` and all `mc/*` branches
- Document branch strategy in `CLAUDE.md`

## Notes

Split from `update/mc-26.1.2` so this infrastructure work can merge independently while the MC 26.1.2 dependency update waits for Architectury API to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)