### PR TITLE
Make Parchment mapping version configurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ subprojects {
         minecraft "net.minecraft:minecraft:$rootProject.minecraft_version"
         mappings loom.layered() {
             officialMojangMappings()
-            parchment("org.parchmentmc.data:parchment-${rootProject.minecraft_version}:2025.12.20@zip")
+            parchment("org.parchmentmc.data:parchment-${rootProject.minecraft_version}:${rootProject.parchment_version}@zip")
         }
         implementation("org.slf4j:slf4j-api:2.0.18")
         implementation("com.github.ben-manes.caffeine:caffeine:3.2.4")

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,7 @@ enabled_platforms = fabric,neoforge
 
 # Minecraft properties
 minecraft_version = 1.21.11
+parchment_version = 2025.12.20
 
 # Dependencies
 architectury_api_version = 19.0.1


### PR DESCRIPTION
Moves the hardcoded Parchment date into `gradle.properties` so each MC version branch can specify its own `parchment_version` independently. Required to support the new `mc/1.21.1` branch.