### PR TITLE
Fix NeoForge shadow JAR module conflicts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ publishMods {
         accessToken = env.fetchOrNull("GITHUB_TOKEN")
         repository = github_repo
         commitish = "main"
-        tagName = "v${project.version}"
+        tagName = "v${mod_version}+${minecraft_version}"
         allowEmptyFiles = true
     }
 }

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -61,6 +61,7 @@ shadowJar {
     configurations = [project.configurations.shadowBundle]
     archiveClassifier = 'dev-shadow'
     relocate 'blue.endless.jankson', 'red.ethel.minecraft.wornpath.jankson'
+    exclude 'com/google/errorprone/**'
 }
 
 remapJar {

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -60,6 +60,7 @@ processResources {
 shadowJar {
     configurations = [project.configurations.shadowBundle]
     archiveClassifier = 'dev-shadow'
+    relocate 'blue.endless.jankson', 'red.ethel.minecraft.wornpath.jankson'
 }
 
 remapJar {


### PR DESCRIPTION
Cherry-picks fixes from `mc/1.21.1` to main:

- Fix GitHub release `tagName` using `project.version` which evaluates as "unspecified" before `allprojects` runs
- Relocate bundled Jankson to a private namespace to avoid conflicts with other mods
- Exclude errorprone annotations (Caffeine transitive dep, compile-time only) from the shadow JAR