### PR TITLE
chore: update to Minecraft 26.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Java 21
+      - name: Set up Java 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@ Each Minecraft version has its own branch:
 
 | Branch | Minecraft version |
 |---|---|
-| `main` | latest supported MC version (26.1.x) |
+| `main` | latest supported MC version (26.2.x) |
+| `mc/26.1.x` | MC 26.1.x |
 | `mc/1.21.11` | MC 1.21.11 |
 | `mc/1.21.1` | MC 1.21.1 |
 
@@ -47,25 +48,25 @@ Platform-agnostic logic goes in `common`. Each platform subproject has a thin en
   - Platform-specific: `.fabric`, `.neoforge`
   - Mixins: `.mixin`
 - **Mod ID**: `worn_path`
-- **Java**: 25 (on main/26.1.x), 21 (on mc/1.21.x branches)
+- **Java**: 25 (on main/26.2.x), 21 (on mc/1.21.x branches)
 - No automated code style enforcement currently configured
 
-## Key Dependencies (main / 26.1.x)
+## Key Dependencies (main / 26.2.x)
 
 | Dependency | Version |
 |---|---|
-| Minecraft | 26.1.2 |
-| Fabric Loader | 0.19.2+ |
-| Fabric API | 0.148.2+26.1.2 |
-| NeoForge | 26.1.2.55-beta |
-| Fabric Loom | 1.16.2 |
+| Minecraft | 26.2 |
+| Fabric Loader | 0.19.3+ |
+| Fabric API | 0.153.0+26.2 |
+| NeoForge | 26.2.0.7-beta |
+| Fabric Loom | 1.17.11 |
 | ModDevGradle | 2.0.141 |
 | Caffeine (caching) | 3.2.4 |
 
-Note: MC 26.1.x is the first unobfuscated Minecraft release — no Mojang mappings or remapping step needed. Use `net.fabricmc.fabric-loom` (not `fabric-loom-remap`) for Fabric builds.
+Note: MC 26.x is unobfuscated — no Mojang mappings or remapping step needed. Use `net.fabricmc.fabric-loom` (not `fabric-loom-remap`) for Fabric builds.
 
 ## Mixins
 
 Config: `common/src/main/resources/worn_path.mixins.json`
 Package: `red.ethel.minecraft.wornpath.mixin`
-Compatibility level: JAVA_21 (update to JAVA_25 for 26.1.x builds)
+Compatibility level: JAVA_21 (update to JAVA_25 for 26.x builds)

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -26,8 +26,8 @@
     "worn_path.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.19.2",
-    "minecraft": "~26.1.2",
+    "fabricloader": ">=0.19.3",
+    "minecraft": "~26.2",
     "java": ">=25",
     "fabric-api": "*"
   },

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,22 +8,22 @@ maven_group = red.ethel.minecraft.wornpath
 archives_name = worn_path
 
 # Minecraft properties
-minecraft_version = 26.1.2
-# parchment_version omitted — no 26.1.x mappings available yet
+minecraft_version = 26.2
+# parchment_version omitted — no mappings needed for 26.x (unobfuscated)
 
 # Dependencies
-fabric_loader_version = 0.19.2
-fabric_api_version = 0.148.2+26.1.2
-fabric_loom_version = 1.16.2
-neoforge_version = 26.1.2.55-beta
+fabric_loader_version = 0.19.3
+fabric_api_version = 0.153.0+26.2
+fabric_loom_version = 1.17.11
+neoforge_version = 26.2.0.7-beta
 moddev_version = 2.0.141
 caffeine_version = 3.2.4
 jankson_version = 1.2.3
 
 # Config dependencies
-# YACL: no 26.1.x fabric release yet; neoforge variant used as compile-only stub in common
+# YACL: no 26.2.x fabric release yet; neoforge variant used as compile-only stub in common
 yacl_version = 3.9.3+26.1-neoforge
-# ModMenu: no 26.1.x release yet; older version used as compile-only type stub
+# ModMenu: no 26.2.x release yet; older version used as compile-only type stub
 modmenu_version = 17.0.0
 
 # Publishing

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -16,14 +16,14 @@ Where players walk, paths may appear.
 [[dependencies.worn_path]]
 modId = "neoforge"
 type = "required"
-versionRange = "[26.1,)"
+versionRange = "[26.2,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.worn_path]]
 modId = "minecraft"
 type = "required"
-versionRange = "[26.1.2,)"
+versionRange = "[26.2,)"
 ordering = "NONE"
 side = "BOTH"
 


### PR DESCRIPTION
## Summary

- Bumps all dependency versions to target MC 26.2 ("Chaos Cubed", released 16 June 2026)
- Creates `mc/26.1.x` branch to preserve 26.1.x support
- No source code changes needed — MC 26.2 breaking changes (Vulkan renderer, entity predicates, touchscreen removal) do not affect this mod

## Dependency changes

| Dependency | Old | New |
|---|---|---|
| Minecraft | 26.1.2 | 26.2 |
| NeoForge | 26.1.2.55-beta | 26.2.0.7-beta |
| Fabric Loader | 0.19.2 | 0.19.3 |
| Fabric API | 0.148.2+26.1.2 | 0.153.0+26.2 |
| Fabric Loom | 1.16.2 | 1.17.11 |

## Test plan

- [x] `./gradlew clean build` passes — produces `worn_path-fabric-1.5.3+26.2` and `worn_path-neoforge-1.5.3+26.2`
- [ ] Launch Fabric client (`./gradlew :fabric:runClient`) and confirm path conversion works in-game
- [ ] Launch NeoForge client (`./gradlew :neoforge:runClient`) and confirm path conversion works in-game

## Notes

- YACL and ModMenu do not yet have 26.2 releases; they remain as compile-only stubs (same pattern as 26.1.x bootstrap)
- `mod_version` bump to 1.5.4 should be done on all branches before publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)